### PR TITLE
Enforce parser statement termination after query parse

### DIFF
--- a/src/main/java/com/coresql/parser/Parser.java
+++ b/src/main/java/com/coresql/parser/Parser.java
@@ -54,15 +54,27 @@ public class Parser {
     }
 
     public Query parse() {
+        Query query;
         if (match(TokenType.KEYWORD, "CREATE")) {
-            return parseCreateTable();
+            query = parseCreateTable();
         } else if (match(TokenType.KEYWORD, "INSERT")) {
-            return parseInsert();
+            query = parseInsert();
         } else if (match(TokenType.KEYWORD, "SELECT")) {
-            return parseSelect();
+            query = parseSelect();
         } else {
             throw new IllegalArgumentException("Syntax error: unexpected token " + peek().value());
         }
+        return ensureStatementEnd(query);
+    }
+
+    private Query ensureStatementEnd(Query query) {
+        if (match(TokenType.SYMBOL, ";")) {
+            // Optional trailing semicolon consumed.
+        }
+        if (!match(TokenType.END_OF_FILE)) {
+            throw new IllegalArgumentException("Syntax error: unexpected token " + peek().value());
+        }
+        return query;
     }
 
     private Query parseCreateTable() {


### PR DESCRIPTION
### Motivation
- Ensure the parser rejects trailing junk after a statement and accepts at most one optional trailing semicolon then EOF so inputs like `SELECT * FROM t junk` fail fast.

### Description
- Change `parse()` to assign the parsed AST to a local `Query query` and return the result of a post-parse check.  
- Add `ensureStatementEnd(Query query)` which consumes one optional `SYMBOL` `;`, requires `END_OF_FILE` immediately after, and throws `IllegalArgumentException` with the unexpected token value if extra tokens remain.  
- Apply the check uniformly after `CREATE`, `INSERT`, and `SELECT` parsing to avoid silently accepting extra tokens.

### Testing
- Attempted to run `mvn test -q`, but the run failed due to Maven dependency resolution returning a `403 Forbidden` while fetching `maven-resources-plugin:3.3.1` from Maven Central so automated tests could not complete.  
- No new unit tests were added in this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c972959740832c8feff987ebdbdbf0)